### PR TITLE
Add configuration interface / API

### DIFF
--- a/cmd/streamdeck/api.go
+++ b/cmd/streamdeck/api.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+func init() {
+	api := router.PathPrefix("/api/v1/").Subrouter()
+	api.HandleFunc("/get-config", handleSerializeUserConfig)
+
+	router.PathPrefix("/")
+
+	router.Use(func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("x-streamdeck-version", version)
+			w.Header().Set("cache-control", "no-cache")
+
+			h.ServeHTTP(w, r)
+		})
+	})
+}
+
+func handleSerializeUserConfig(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("content-type", "application/json")
+
+	if err := json.NewEncoder(w).Encode(userConfig); err != nil {
+		log.WithError(err).Error("Unable to marshal user config")
+		http.Error(w, errors.Wrap(err, "marshal user config").Error(), http.StatusInternalServerError)
+		return
+	}
+}

--- a/cmd/streamdeck/config.go
+++ b/cmd/streamdeck/config.go
@@ -68,6 +68,7 @@ func (a attributeCollection) RGBAToColor() color.RGBA {
 }
 
 type config struct {
+	APIListen         string          `json:"api_listen" yaml:"api_listen"`
 	AutoReload        bool            `json:"auto_reload" yaml:"auto_reload"`
 	CaptionBorder     int             `json:"caption_border" yaml:"caption_border"`
 	CaptionColor      [4]int          `json:"caption_color" yaml:"caption_color"`

--- a/cmd/streamdeck/go.mod
+++ b/cmd/streamdeck/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/Luzifer/streamdeck v0.0.0-20191122003228-a2f524a6b22c
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
+	github.com/gorilla/mux v1.8.0
 	github.com/jfreymuth/pulse v0.0.0-20200804114219-7d61c4938214
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646

--- a/cmd/streamdeck/go.sum
+++ b/cmd/streamdeck/go.sum
@@ -10,6 +10,8 @@ github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf/go.mod h1:hyb9oH7vZsitZCiBt0ZvifOrB+qc8PS5IiilCIb87rg=
 github.com/jfreymuth/pulse v0.0.0-20200804114219-7d61c4938214 h1:2xVJKIumEUWeV3vczQwn61SHjNZ94Bwk+4CTjmcePxk=
 github.com/jfreymuth/pulse v0.0.0-20200804114219-7d61c4938214/go.mod h1:cpYspI6YljhkUf1WLXLLDmeaaPFc3CnGLjDZf9dZ4no=


### PR DESCRIPTION
TODO:

- [ ] Add virtual Streamdeck caching-wrapper around physical one
- [ ] Add interface for virtual Streamdeck
- [ ] Add editor mode to interface
- [ ] Add API to "stream" button changes via Socket
- [ ] Add API to set config from editor mode
- [ ] Adjust Wiki pages for breaking changes

Breaking changes:
- `interval` is now configured as `duration`, not as `int`
- Display modules `exec` and `pulseaudio` now use `rgba` instead of `color` for color configuration