### PR TITLE
Add Meta/Windows/Super_L modifier

### DIFF
--- a/cmd/streamdeck/action_keyPress.go
+++ b/cmd/streamdeck/action_keyPress.go
@@ -47,23 +47,30 @@ func (actionKeyPress) Execute(attributes attributeCollection) error {
 
 	if attributes.ModShift {
 		if err := kbd.KeyDown(uinput.KeyLeftShift); err != nil {
-			return errors.Wrap(err, "Unable to set shift")
+			return errors.Wrap(err, "Unable to set Shift key")
 		}
 		defer kbd.KeyUp(uinput.KeyLeftShift)
 	}
 
 	if attributes.ModAlt {
 		if err := kbd.KeyDown(uinput.KeyLeftAlt); err != nil {
-			return errors.Wrap(err, "Unable to set shift")
+			return errors.Wrap(err, "Unable to set Alt key")
 		}
 		defer kbd.KeyUp(uinput.KeyLeftAlt)
 	}
 
 	if attributes.ModCtrl {
 		if err := kbd.KeyDown(uinput.KeyLeftCtrl); err != nil {
-			return errors.Wrap(err, "Unable to set shift")
+			return errors.Wrap(err, "Unable to set Ctrl key")
 		}
 		defer kbd.KeyUp(uinput.KeyLeftCtrl)
+	}
+
+	if attributes.ModMeta {
+		if err := kbd.KeyDown(uinput.KeyLeftMeta); err != nil {
+			return errors.Wrap(err, "Unable to set Meta key")
+		}
+		defer kbd.KeyUp(uinput.KeyLeftMeta)
 	}
 
 	for _, kc := range execCodes {

--- a/cmd/streamdeck/config.go
+++ b/cmd/streamdeck/config.go
@@ -37,6 +37,7 @@ type attributeCollection struct {
 	ModAlt       bool              `json:"mod_alt,omitempty" yaml:"mod_alt,omitempty"`
 	ModCtrl      bool              `json:"mod_ctrl,omitempty" yaml:"mod_ctrl,omitempty"`
 	ModShift     bool              `json:"mod_shift,omitempty" yaml:"mod_shift,omitempty"`
+	ModMeta      bool              `json:"mod_meta,omitempty" yaml:"mod_meta,omitempty"`
 	Mute         string            `json:"mute,omitempty" yaml:"mute,omitempty"`
 	Name         string            `json:"name,omitempty" yaml:"name,omitempty"`
 	Path         string            `json:"path,omitempty" yaml:"path,omitempty"`


### PR DESCRIPTION
Adds the Meta / Super_L / Mod4 / Windows / Tux key to the list of known modifiers. It is often used in this role in more exotic Window Managers, such as Fluxbox, i3 or awesome.

I decided to go for the "Meta"-name, mostly because that's also how go-uinput refers to the keycode.

Unfortunately, my Go isn't strong enough to find a more generic way to handle this other than copy paste.

~~Edit: Just recognized that I forgot to add the relevant info to the docs, will do later.~~

Edit 2: I couldn't find any workflow associated with updating the wiki, so I went for the good old `format-patch` and put the output as attachment. It is a patch, but it needs to be `.txt` for GH to accept the file...
[0001-Add-mod-meta-to-docs.txt](https://github.com/Luzifer/streamdeck/files/6400409/0001-Add-mod-meta-to-docs.txt)


